### PR TITLE
feature/PKS005-sidemenu サイドメニューコンポーネントの実装

### DIFF
--- a/components/admin/SideMenu.tsx
+++ b/components/admin/SideMenu.tsx
@@ -25,11 +25,11 @@ const SideMenu = () => {
           <MenuItemCalender icon='▶️' link='/admin/'>
             カレンダー
           </MenuItemCalender>
-          <MenuItem link='/admin/cleaning_status_list/'>・清掃状況管理</MenuItem>
-          <MenuItem link='/admin/guesthouse_list/'>・民泊施設情報</MenuItem>
-          <MenuItem link='/admin/staff_list/'>・清掃員情報</MenuItem>
-          <MenuItem link='/admin/settings/'>・管理者情報</MenuItem>
-          <MenuItem link=''>・ログアウト</MenuItem>
+          <MenuItem link='/admin/cleaning_status_list/'>清掃状況管理</MenuItem>
+          <MenuItem link='/admin/guesthouse_list/'>民泊施設情報</MenuItem>
+          <MenuItem link='/admin/staff_list/'>清掃員情報</MenuItem>
+          <MenuItem link='/admin/settings/'>管理者情報</MenuItem>
+          <MenuItem link=''>ログアウト</MenuItem>
         </div>
       </div>
     </div>

--- a/components/admin/SideMenu.tsx
+++ b/components/admin/SideMenu.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Link from 'next/link'
+import React, { useState } from 'react'
+
+const SideMenu = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen)
+  }
+
+  return (
+    <div className='side-menu bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
+      <div className='bg-orange-500 title px-4 py-4 my-4 text-xl'>パクカンシステム</div>
+      <div className='h-screen bg-yellow-800 px-4 py-4'>
+        <div
+          className='menu-toggle border-b-4 border-b-orange-500'
+          onClick={handleToggle}
+        >
+          <p className='px-4 pb-2 text-white text-xl'>MENU</p>
+        </div>
+        <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
+          <MenuItemCalender icon='▶️' link='/admin/'>
+            カレンダー
+          </MenuItemCalender>
+          <MenuItem link='/admin/cleaning_status_list/'>・清掃状況管理</MenuItem>
+          <MenuItem link='/admin/guesthouse_list/'>・民泊施設情報</MenuItem>
+          <MenuItem link='/admin/staff_list/'>・清掃員情報</MenuItem>
+          <MenuItem link='/admin/settings/'>・管理者情報</MenuItem>
+          <MenuItem link=''>・ログアウト</MenuItem>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const MenuItemCalender = ({
+  children,
+  icon = '▶️',
+  link,
+}: {
+  children: React.ReactNode
+  icon?: string
+  link: string
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const handleExpand = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  const handleMouseEnter = () => {
+    setIsExpanded(true)
+  }
+
+  const handleMouseLeave = () => {
+    setIsExpanded(false)
+  }
+
+  return (
+    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <div className='menu-item bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        <Link href={link} className=''>
+          <div className='item-header' onClick={handleExpand}>
+            {isExpanded && children === 'カレンダー' ? '▼' : icon} {children}
+          </div>
+        </Link>
+      </div>
+      {isExpanded && children === 'カレンダー' && (
+        <div className='sub-menu text-sm ml-2'>
+          <Link href='admin/stay_schedule/create/' className='menu-item'>
+            <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+              ・宿泊スケジュール作成
+            </div>
+          </Link>
+          <Link href='admin/staff_schedule/create/' className='menu-item'>
+            <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+              ・清掃員スケジュール作成
+            </div>
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
+  return (
+    <Link href={link} className='menu-item'>
+      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        {children}
+      </div>
+    </Link>
+  )
+}
+
+export default SideMenu

--- a/components/admin/SideMenu.tsx
+++ b/components/admin/SideMenu.tsx
@@ -22,9 +22,7 @@ const SideMenu = () => {
           <p className='px-4 pb-2 text-white text-xl'>MENU</p>
         </div>
         <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
-          <MenuItemCalender icon='▶️' link='/admin/'>
-            カレンダー
-          </MenuItemCalender>
+          <MenuItemCalender />
           <MenuItem link='/admin/cleaning_status_list/'>清掃状況管理</MenuItem>
           <MenuItem link='/admin/guesthouse_list/'>民泊施設情報</MenuItem>
           <MenuItem link='/admin/staff_list/'>清掃員情報</MenuItem>
@@ -36,15 +34,7 @@ const SideMenu = () => {
   )
 }
 
-const MenuItemCalender = ({
-  children,
-  icon = '▶️',
-  link,
-}: {
-  children: React.ReactNode
-  icon?: string
-  link: string
-}) => {
+const MenuItemCalender = () => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   const handleExpand = () => {
@@ -61,25 +51,17 @@ const MenuItemCalender = ({
 
   return (
     <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-      <div className='menu-item bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-        <Link href={link} className=''>
+      <div className='text-start bg-orange-200 text-gray-950 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        <Link href='/admin' className=''>
           <div className='item-header' onClick={handleExpand}>
-            {isExpanded && children === 'カレンダー' ? '▼' : icon} {children}
+            {isExpanded ? '▼' : '▶️'} カレンダー
           </div>
         </Link>
       </div>
-      {isExpanded && children === 'カレンダー' && (
-        <div className='sub-menu text-sm ml-2'>
-          <Link href='admin/stay_schedule/create/' className='menu-item'>
-            <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-              ・宿泊スケジュール作成
-            </div>
-          </Link>
-          <Link href='admin/staff_schedule/create/' className='menu-item'>
-            <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-              ・清掃員スケジュール作成
-            </div>
-          </Link>
+      {isExpanded && (
+        <div className='text-sm ml-2'>
+          <MenuItem link='admin/stay_schedule/create'>宿泊スケジュール作成</MenuItem>
+          <MenuItem link='admin/staff_schedule/create'>清掃員スケジュール作成</MenuItem>
         </div>
       )}
     </div>

--- a/components/admin/SideMenu.tsx
+++ b/components/admin/SideMenu.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import React, { useState } from 'react'
+import MenuItem from '@/components/sidemenu/MenuItem'
 
 const SideMenu = () => {
   const [isOpen, setIsOpen] = useState(false)
@@ -82,16 +83,6 @@ const MenuItemCalender = ({
         </div>
       )}
     </div>
-  )
-}
-
-const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
-  return (
-    <Link href={link} className='menu-item'>
-      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-        {children}
-      </div>
-    </Link>
   )
 }
 

--- a/components/admin/SideMenu.tsx
+++ b/components/admin/SideMenu.tsx
@@ -12,13 +12,10 @@ const SideMenu = () => {
   }
 
   return (
-    <div className='side-menu bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
-      <div className='bg-orange-500 title px-4 py-4 my-4 text-xl'>パクカンシステム</div>
+    <div className='bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
+      <div className='bg-orange-500 px-4 py-4 my-4 text-xl'>パクカンシステム</div>
       <div className='h-screen bg-yellow-800 px-4 py-4'>
-        <div
-          className='menu-toggle border-b-4 border-b-orange-500'
-          onClick={handleToggle}
-        >
+        <div className='border-b-4 border-b-orange-500' onClick={handleToggle}>
           <p className='px-4 pb-2 text-white text-xl'>MENU</p>
         </div>
         <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
@@ -53,9 +50,7 @@ const MenuItemCalender = () => {
     <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <div className='text-start bg-orange-200 text-gray-950 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
         <Link href='/admin' className=''>
-          <div className='item-header' onClick={handleExpand}>
-            {isExpanded ? '▼' : '▶️'} カレンダー
-          </div>
+          <div onClick={handleExpand}>{isExpanded ? '▼' : '▶️'} カレンダー</div>
         </Link>
       </div>
       {isExpanded && (

--- a/components/sidemenu/MenuItem.tsx
+++ b/components/sidemenu/MenuItem.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
+  return (
+    <Link href={link} className='menu-item'>
+      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        {children}
+      </div>
+    </Link>
+  )
+}
+
+export default MenuItem

--- a/components/sidemenu/MenuItem.tsx
+++ b/components/sidemenu/MenuItem.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link'
 
 const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
   return (
-    <Link href={link} className='menu-item'>
-      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-        {children}
+    <Link href={link}>
+      <div className='text-start bg-orange-200 text-gray-950 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        ・{children}
       </div>
     </Link>
   )

--- a/components/staff/SideMenu.tsx
+++ b/components/staff/SideMenu.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import React, { useState } from 'react'
+
+const SideMenu = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen)
+  }
+
+  return (
+    <div className='side-menu bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
+      <div className='bg-orange-500 title px-4 py-4 my-4 text-xl'>パクカンシステム</div>
+      <div className='h-screen bg-yellow-800 px-4 py-4'>
+        <div
+          className='menu-toggle border-b-4 border-b-orange-500'
+          onClick={handleToggle}
+        >
+          <p className='px-4 pb-2 text-white text-xl'>MENU</p>
+        </div>
+        <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
+          <MenuItem link='/admin/cleaning_status_list/'>・カレンダー</MenuItem>
+          <MenuItem link='/admin/guesthouse_list/'>・登録情報</MenuItem>
+          <MenuItem link=''>・ログアウト</MenuItem>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
+  return (
+    <Link href={link} className='menu-item'>
+      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
+        {children}
+      </div>
+    </Link>
+  )
+}
+
+export default SideMenu

--- a/components/staff/SideMenu.tsx
+++ b/components/staff/SideMenu.tsx
@@ -11,16 +11,13 @@ const SideMenu = () => {
   }
 
   return (
-    <div className='side-menu bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
-      <div className='bg-orange-500 title px-4 py-4 my-4 text-xl'>パクカンシステム</div>
+    <div className='bg-gray-200 h-screen w-72 fixed left-0 top-0 px-4 text-sm'>
+      <div className='bg-orange-500 px-4 py-4 my-4 text-xl'>パクカンシステム</div>
       <div className='h-screen bg-yellow-800 px-4 py-4'>
-        <div
-          className='menu-toggle border-b-4 border-b-orange-500'
-          onClick={handleToggle}
-        >
+        <div className='border-b-4 border-b-orange-500' onClick={handleToggle}>
           <p className='px-4 pb-2 text-white text-xl'>MENU</p>
         </div>
-        <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
+        <div className='py-2'>
           <MenuItem link='/staff'>カレンダー</MenuItem>
           <MenuItem link='/staff/settings'>登録情報</MenuItem>
           <MenuItem link=''>ログアウト</MenuItem>

--- a/components/staff/SideMenu.tsx
+++ b/components/staff/SideMenu.tsx
@@ -21,9 +21,9 @@ const SideMenu = () => {
           <p className='px-4 pb-2 text-white text-xl'>MENU</p>
         </div>
         <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
-          <MenuItem link='/staff'>・カレンダー</MenuItem>
-          <MenuItem link='/staff/settings'>・登録情報</MenuItem>
-          <MenuItem link=''>・ログアウト</MenuItem>
+          <MenuItem link='/staff'>カレンダー</MenuItem>
+          <MenuItem link='/staff/settings'>登録情報</MenuItem>
+          <MenuItem link=''>ログアウト</MenuItem>
         </div>
       </div>
     </div>

--- a/components/staff/SideMenu.tsx
+++ b/components/staff/SideMenu.tsx
@@ -21,8 +21,8 @@ const SideMenu = () => {
           <p className='px-4 pb-2 text-white text-xl'>MENU</p>
         </div>
         <div className={`menu-items py-2 ${isOpen ? 'open' : ''}`}>
-          <MenuItem link='/admin/cleaning_status_list/'>・カレンダー</MenuItem>
-          <MenuItem link='/admin/guesthouse_list/'>・登録情報</MenuItem>
+          <MenuItem link='/staff'>・カレンダー</MenuItem>
+          <MenuItem link='/staff/settings'>・登録情報</MenuItem>
           <MenuItem link=''>・ログアウト</MenuItem>
         </div>
       </div>

--- a/components/staff/SideMenu.tsx
+++ b/components/staff/SideMenu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import React, { useState } from 'react'
+import MenuItem from '@/components/sidemenu/MenuItem'
 
 const SideMenu = () => {
   const [isOpen, setIsOpen] = useState(false)
@@ -27,16 +27,6 @@ const SideMenu = () => {
         </div>
       </div>
     </div>
-  )
-}
-
-const MenuItem = ({ children, link }: { children: React.ReactNode; link: string }) => {
-  return (
-    <Link href={link} className='menu-item'>
-      <div className='bg-orange-200 pl-4 my-2 py-2 hover:bg-orange-100 hover:text-gray-600'>
-        {children}
-      </div>
-    </Link>
   )
 }
 


### PR DESCRIPTION
- チケット内容. 
サイドメニューの実装
管理者画面設計：https://docs.google.com/spreadsheets/d/1odTZz_oJ0HnINbThMwnzwEV3MJMV-zXzL2YE7bWbLbE/edit#gid=431173827
清掃員画面設計：https://docs.google.com/spreadsheets/d/1odTZz_oJ0HnINbThMwnzwEV3MJMV-zXzL2YE7bWbLbE/edit#gid=231809631

- 実装内容. 
・ホバー時に色をかえる。
・管理者におけるカレンダーホバー時に二つのサブメニュー表示 

- 動作確認方法. 
任意のpage.tsxに以下記載. 
`import SideMenu from '@/components/admin/SideMenu'` or `import SideMenu from '@/components/admin/SideMenu'`
return直下に以下記載
```
<div className='flex'>
      <SideMenu />
```
<img width="284" alt="image" src="https://github.com/KengoKonishi/pakukan_app/assets/84663136/c3bb797e-2d0c-48e4-86ca-dd45ef92985d">
